### PR TITLE
Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(GTest)
 
 # Headers
 include_directories (${CMAKE_SOURCE_DIR}/include)
-include_directories (${ASIO_INCLUDE_DIR})
 
 if(THREADS_HAVE_PTHREAD_ARG)
   compile_options(PUBLIC"-pthread")
@@ -42,7 +41,9 @@ endif()
 
 # Compiler
 set (CMAKE_CXX_STANDARD 11)
-add_definitions(-DASIO_STANDALONE)
+if (ASIO_STANDALONE)
+  add_definitions(-DASIO_STANDALONE=1)
+endif()
 add_definitions(-DELPP_THREAD_SAFE)
 add_definitions(-DELPP_DISABLE_DEFAULT_CRASH_HANDLING)
 add_definitions(-Wall)
@@ -60,6 +61,7 @@ add_library(luciconnect SHARED
   "${CMAKE_SOURCE_DIR}/src/connection.cc"
   "${CMAKE_SOURCE_DIR}/src/message.cc"
   "${CMAKE_SOURCE_DIR}/src/md5/md5.cc")
+target_link_libraries(luciconnect PUBLIC asio)
 
 # Testing
 if (GTEST_FOUND)

--- a/cmake/modules/FindAsio.cmake
+++ b/cmake/modules/FindAsio.cmake
@@ -1,12 +1,25 @@
-if (WIN32)
-  find_package(Boost REQUIRED)
-  set (ASIO_INCLUDE_DIR "${Boost_INCLUDE_DIR}")
-  set (ASIO_LIBRARY ${ASIO_INCLUDE_DIR})
-else (WIN32)
-  find_path (ASIO_INCLUDE_DIR NAMES asio HINTS "/usr/include" "/usr/local/include" "/opt/local/include")
-  set (ASIO_LIBRARY ${ASIO_INCLUDE_DIR})
-endif (WIN32)
+if (NOT ASIO_FOUND)
+	# Try standalone Asio first
+	find_path (ASIO_INCLUDE_DIR NAMES asio HINTS "/usr/include" "/usr/local/include" "/opt/local/include")
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Asio DEFAULT_MSG ASIO_LIBRARY ASIO_INCLUDE_DIR)
-mark_as_advanced(ASIO_INCLUDE_DIR ASIO_LIBRARY)
+	if (NOT ASIO_INCLUDE_DIR)
+	  # Try Boost.Asio
+	  find_package(Boost COMPONENTS system REQUIRED)
+	  set (ASIO_STANDALONE FALSE)
+	else()
+	  set (ASIO_STANDALONE TRUE)
+	endif()
+
+	if (ASIO_STANDALONE)
+		add_library(asio INTERFACE IMPORTED)
+		set_target_properties(asio PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${ASIO_INCLUDE_DIR}
+		)
+	else()
+		add_library(asio INTERFACE IMPORTED)
+		set_target_properties(asio PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIR}
+			INTERFACE_LINK_LIBRARIES ${Boost_SYSTEM_LIBRARY}
+		)
+	endif()
+endif()

--- a/include/luciconnect/asio.h
+++ b/include/luciconnect/asio.h
@@ -1,0 +1,16 @@
+#ifndef luciconnect_ASIO_H
+#define luciconnect_ASIO_H
+
+#ifdef ASIO_STANDALONE
+#include <asio.hpp>
+#else
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+namespace asio
+{
+	using namespace boost::asio;
+	using namespace boost::system;
+}
+#endif
+
+#endif

--- a/include/luciconnect/connection.h
+++ b/include/luciconnect/connection.h
@@ -14,6 +14,7 @@
 #include <thread>
 #include <mutex>
 #include <chrono> // for sleeping
+#include <atomic>
 
 using json = nlohmann::json;
 

--- a/include/luciconnect/connection.h
+++ b/include/luciconnect/connection.h
@@ -4,8 +4,8 @@
 #include "luciconnect/json/json.hpp"
 #include "luciconnect/easylogging/easylogging++.h"
 #include "luciconnect/message.h"
+#include "luciconnect/asio.h"
 
-#include <asio.hpp>
 #include <vector>
 #include <string>
 #include <algorithm> // std::reverse

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -1,5 +1,7 @@
 #include "luciconnect/connection.h"
 
+#include <boost/asio/connect.hpp>
+
 using std::placeholders::_1;
 using std::placeholders::_2;
 


### PR DESCRIPTION
I've hacked the code a bit so that it actually works with both standalone Asio and Boost.Asio (this is done in include/luciconnect/asio.h).

FindAsio.cmake looks for a standalone version first. Asio is linked as an imported target, which is the standard way in modern CMake.